### PR TITLE
Fixed denmark christmas holidays

### DIFF
--- a/locale/denmark.js
+++ b/locale/denmark.js
@@ -42,8 +42,13 @@
       date: '12/24',
       keywords: ['christmas']
     },
-    "Anden juledag": {
+    "Juledag": {
       date: '12/25',
+      keywords: ['juledag'],
+      keywords_y: ['anden']
+    },
+    "Anden juledag": {
+      date: '12/26',
       keywords: ['andenjuledag'],
       keywords_y: ['anden']
     }


### PR DESCRIPTION
In Denmark the 24th is Christmas eve (Juleaften) 25th is "Christmas day" (juledag) and the 26th is "second Christmas day" (anden juledag)